### PR TITLE
[CWE-089] Add initial code for SQLAlchemy injection query

### DIFF
--- a/python/ql/src/experimental/Security/CWE-089/SqlAlchemyInjection.qhelp
+++ b/python/ql/src/experimental/Security/CWE-089/SqlAlchemyInjection.qhelp
@@ -1,0 +1,36 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+  <p>
+  Passing user-controlled sources into SQL queries used in SQLAlchemy methods can result in a SQL injection flaw.
+  This tainted SQL query containing a user-controlled source when passed into a SQLAlchemy method can execute a malicious query in a SQL database such as Postgres, MySQL, or SQLite.
+  </p>
+
+  <p>
+  Because a user-controlled source is passed into the query, the malicious user can have complete control over the query itself.
+  When the tainted query is executed, the malicious user can commit malicious actions such as bypassing role restrictions or accessing and modifying restricted data in the SQL database.
+  </p>
+</overview>
+
+<recommendation>
+  <p>
+  SQL injections can be prevented by escaping user-input's special characters that are passed into the SQL query from the user-supplied source.
+  Alternatively, using a sanitize library such as Sqlescapy will ensure that user-supplied sources can not act as a malicious query.
+  </p>
+<recommendation>
+
+<example>
+  <p>In the example below, the user-supplied source is passed to a SQLAlchemy method that queries the SQLite database.</p>
+  <sample src="SqlAlchemyInjection-Bad.py" />
+  <p> This can be fixed by using a sanitizer library like Sqlescapy as shown in this annotated code version below.</p>
+  <sample src="SqlAlchemyInjection-Good.py" />
+<example>
+
+<references>
+  <li>OWASP: <a href="https://owasp.org/www-community/attacks/SQL_Injection">SQL Injection</a></li>
+  <li>SQLAlchemy: <a href="https://docs.sqlalchemy.org/en/14/index.html">Documentation</a></li>
+</references>
+</qhelp>

--- a/python/ql/src/experimental/Security/CWE-089/SqlAlchemyInjection.ql
+++ b/python/ql/src/experimental/Security/CWE-089/SqlAlchemyInjection.ql
@@ -13,7 +13,7 @@
 import python
 import experimental.semmle.python.security.injection.SqlAlchemyInjection
 
-from CustomPathNode source, CustomPathNode sink
-where SqlAlchemyInjectionFlow(source, sink)
+from DataFlow::PathNode source, DataFlow::PathNode sink, SqlAlchemyInjectionConfig sqlAlchemyInjectionConfig
+where sqlAlchemyInjectionConfig.hasFlowPath(source, sink)
 select sink, source, sink, "$@ SQL query contains an unsanitized $@", sink, "This", source,
   "user-provided value"

--- a/python/ql/src/experimental/Security/CWE-089/SqlAlchemyInjection.ql
+++ b/python/ql/src/experimental/Security/CWE-089/SqlAlchemyInjection.ql
@@ -1,0 +1,19 @@
+/**
+ * @name SqlAlchemy Injection
+ * @description Building a SQL query from user-controlled sources is vulnerable to insertion of
+ *              malicious SQL code by the user in SQLAlchemy.
+ * @kind path-problem
+ * @problem.severity error
+ * @id python/sqlalchemy-injection
+ * @tags experimental
+ *       security
+ *       external/cwe/cwe-089
+ */
+
+import python
+import experimental.semmle.python.security.injection.SqlAlchemyInjection
+
+from CustomPathNode source, CustomPathNode sink
+where SqlAlchemyInjectionFlow(source, sink)
+select sink, source, sink, "$@ SQL query contains an unsanitized $@", sink, "This", source,
+  "user-provided value"

--- a/python/ql/src/experimental/semmle/python/Concepts.qll
+++ b/python/ql/src/experimental/semmle/python/Concepts.qll
@@ -13,3 +13,17 @@ private import semmle.python.dataflow.new.DataFlow
 private import semmle.python.dataflow.new.RemoteFlowSources
 private import semmle.python.dataflow.new.TaintTracking
 private import experimental.semmle.python.Frameworks
+
+module SqlSanitizer {
+  abstract class Range extends DataFlow::Node {
+    abstract DataFlow::Node getSanitizerNode();
+  }
+}
+
+class SqlSanitizer extends DataFlow::Node {
+  SqlSanitizer::Range range;
+
+  SqlSanitizer() { this = range }
+
+  DataFlow::Node getSanitizerNode() { result = range.getSanitizerNode() }
+}

--- a/python/ql/src/experimental/semmle/python/frameworks/Stdlib.qll
+++ b/python/ql/src/experimental/semmle/python/frameworks/Stdlib.qll
@@ -8,4 +8,18 @@ private import semmle.python.dataflow.new.DataFlow
 private import semmle.python.dataflow.new.TaintTracking
 private import semmle.python.dataflow.new.RemoteFlowSources
 private import experimental.semmle.python.Concepts
+private import semmle.python.Concepts
 private import semmle.python.ApiGraphs
+
+private module SQL {
+  // TODO: We need to add the SqlExecution::Range subclasses that cover SqlAlchemy sinks
+
+  private class SqlSanitizerCall extends DataFlow::CallCfgNode, NoSQLSanitizer::Range {
+    SqlSanitizerCall() {
+      this =
+        API::moduleImport("sqlescapy").getMember("sqlescape").getACall()
+    }
+
+    override DataFlow::Node getSanitizerNode() { result = this.getArg(0) }
+  }
+}

--- a/python/ql/src/experimental/semmle/python/security/injection/SQLAlchemyInjection.qll
+++ b/python/ql/src/experimental/semmle/python/security/injection/SQLAlchemyInjection.qll
@@ -1,0 +1,72 @@
+import python
+import semmle.python.dataflow.new.DataFlow
+import semmle.python.dataflow.new.DataFlow2
+import semmle.python.dataflow.new.TaintTracking
+import semmle.python.dataflow.new.TaintTracking2
+import experimental.semmle.python.Concepts
+import semmle.python.dataflow.new.RemoteFlowSources
+import semmle.python.ApiGraphs
+import semmle.python.security.dataflow.ChainedConfigs12
+
+class JsonLoadsCall extends DataFlow::CallCfgNode {
+  JsonLoadsCall() { this = API::moduleImport("json").getMember("loads").getACall() }
+
+  DataFlow::Node getLoadNode() { result = this.getArg(0) }
+}
+
+class XmlToDictParseCall extends DataFlow::CallCfgNode {
+  XmlToDictParseCall() { this = API::moduleImport("xmltodict").getMember("parse").getACall() }
+
+  DataFlow::Node getParseNode() { result = this.getArg(0) }
+}
+
+class UltraJsonLoadsCall extends DataFlow::CallCfgNode {
+  UltraJsonLoadsCall() { this = API::moduleImport("ujson").getMember("loads").getACall() }
+
+  DataFlow::Node getLoadNode() { result = this.getArg(0) }
+}
+
+class DataToDictSink extends DataFlow::Node {
+  DataToDictSink() {
+    this = any(JsonLoadsCall jsonLoads).getLoadNode() or
+    this = any(XmlToDictParseCall jsonLoads).getParseNode() or
+    this = any(UltraJsonLoadsCall jsonLoads).getLoadNode()
+  }
+}
+
+class RFSToDictConfig extends TaintTracking::Configuration {
+  RFSToDictConfig() { this = "RFSToDictConfig" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+  override predicate isSink(DataFlow::Node sink) { sink instanceof DataToDictSink }
+
+  override predicate isSanitizer(DataFlow::Node sanitizer) {
+    sanitizer = any(SqlSanitizer SqlSanitizer).getSanitizerNode()
+  }
+}
+
+class FromDataDictToSink extends TaintTracking2::Configuration {
+  FromDataDictToSink() { this = "FromDataDictToSink" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof DataToDictSink }
+
+  override predicate isSink(DataFlow::Node sink) {
+    sink = any(SqlAlchemyQuery SqlAlchemyQuery).getQueryNode()
+  }
+
+  override predicate isSanitizer(DataFlow::Node sanitizer) {
+    sanitizer = any(SqlSanitizer SqlSanitizer).getSanitizerNode()
+  }
+}
+
+predicate SqlAlchemyInjectionFlow(CustomPathNode source, CustomPathNode sink) {
+  exists(
+    RFSToDictConfig config, DataFlow::PathNode mid1, DataFlow2::PathNode mid2,
+    FromDataDictToSink config2
+  |
+    config.hasFlowPath(source.asNode1(), mid1) and
+    config2.hasFlowPath(mid2, sink.asNode2()) and
+    mid1.getNode().asCfgNode() = mid2.getNode().asCfgNode()
+  )
+}

--- a/python/ql/src/experimental/semmle/python/security/injection/SQLAlchemyInjection.qll
+++ b/python/ql/src/experimental/semmle/python/security/injection/SQLAlchemyInjection.qll
@@ -1,72 +1,19 @@
 import python
 import semmle.python.dataflow.new.DataFlow
-import semmle.python.dataflow.new.DataFlow2
 import semmle.python.dataflow.new.TaintTracking
-import semmle.python.dataflow.new.TaintTracking2
 import experimental.semmle.python.Concepts
 import semmle.python.dataflow.new.RemoteFlowSources
 import semmle.python.ApiGraphs
-import semmle.python.security.dataflow.ChainedConfigs12
+import experimental.semmle.python.frameworks.Stdlib
 
-class JsonLoadsCall extends DataFlow::CallCfgNode {
-  JsonLoadsCall() { this = API::moduleImport("json").getMember("loads").getACall() }
-
-  DataFlow::Node getLoadNode() { result = this.getArg(0) }
-}
-
-class XmlToDictParseCall extends DataFlow::CallCfgNode {
-  XmlToDictParseCall() { this = API::moduleImport("xmltodict").getMember("parse").getACall() }
-
-  DataFlow::Node getParseNode() { result = this.getArg(0) }
-}
-
-class UltraJsonLoadsCall extends DataFlow::CallCfgNode {
-  UltraJsonLoadsCall() { this = API::moduleImport("ujson").getMember("loads").getACall() }
-
-  DataFlow::Node getLoadNode() { result = this.getArg(0) }
-}
-
-class DataToDictSink extends DataFlow::Node {
-  DataToDictSink() {
-    this = any(JsonLoadsCall jsonLoads).getLoadNode() or
-    this = any(XmlToDictParseCall jsonLoads).getParseNode() or
-    this = any(UltraJsonLoadsCall jsonLoads).getLoadNode()
-  }
-}
-
-class RFSToDictConfig extends TaintTracking::Configuration {
-  RFSToDictConfig() { this = "RFSToDictConfig" }
+class SqlAlchemyInjectionConfig extends TaintTracking::Configuration {
+  SqlAlchemyInjectionConfig() { this = "SqlAlchemyInjectionConfig" }
 
   override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
-  override predicate isSink(DataFlow::Node sink) { sink instanceof DataToDictSink }
+  override predicate isSink(DataFlow::Node sink) { sink instanceof SqlAlchemyInjectionSink }
 
   override predicate isSanitizer(DataFlow::Node sanitizer) {
     sanitizer = any(SqlSanitizer SqlSanitizer).getSanitizerNode()
   }
-}
-
-class FromDataDictToSink extends TaintTracking2::Configuration {
-  FromDataDictToSink() { this = "FromDataDictToSink" }
-
-  override predicate isSource(DataFlow::Node source) { source instanceof DataToDictSink }
-
-  override predicate isSink(DataFlow::Node sink) {
-    sink = any(SqlAlchemyQuery SqlAlchemyQuery).getQueryNode()
-  }
-
-  override predicate isSanitizer(DataFlow::Node sanitizer) {
-    sanitizer = any(SqlSanitizer SqlSanitizer).getSanitizerNode()
-  }
-}
-
-predicate SqlAlchemyInjectionFlow(CustomPathNode source, CustomPathNode sink) {
-  exists(
-    RFSToDictConfig config, DataFlow::PathNode mid1, DataFlow2::PathNode mid2,
-    FromDataDictToSink config2
-  |
-    config.hasFlowPath(source.asNode1(), mid1) and
-    config2.hasFlowPath(mid2, sink.asNode2()) and
-    mid1.getNode().asCfgNode() = mid2.getNode().asCfgNode()
-  )
 }

--- a/python/ql/test/experimental/query-tests/Security/CWE-089/sqlalchemy_bad.py
+++ b/python/ql/test/experimental/query-tests/Security/CWE-089/sqlalchemy_bad.py
@@ -1,0 +1,33 @@
+import sqlalchemy
+from sqlalchemy import Column, Integer, String, ForeignKey, create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship, backref, sessionmaker, joinedload
+from sqlalchemy.sql import text
+from sqlescapy import sqlescape
+
+
+engine = create_engine('sqlite:///:memory:', echo=True)
+Base = declarative_base()
+
+class User(Base):
+    __tablename__ = 'users'
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+
+Base.metadata.create_all(engine)
+
+Session = sessionmaker(bind=engine)
+session = Session()
+
+ed_user = User(name='ed')
+ed_user2 = User(name='george')
+
+session.add(ed_user)
+session.add(ed_user2)
+
+session.commit()
+
+malicious_user_input = sys.argv[1]
+malicious_user_input = text("name='{}'".format(malicious_user_input))
+session.query(User).filter(malicious_user_input).count()

--- a/python/ql/test/experimental/query-tests/Security/CWE-089/sqlalchemy_flask_bad.py
+++ b/python/ql/test/experimental/query-tests/Security/CWE-089/sqlalchemy_flask_bad.py
@@ -1,0 +1,36 @@
+from flask import Flask, request
+from flask_sqlalchemy import SQLAlchemy
+import json
+from sqlalchemy.sql import text
+
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+app.config['SQLALCHEMY_ECHO'] = True
+db = SQLAlchemy(app)
+
+class User(db.Model):
+    uid = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    email = db.Column(db.String(50))
+
+    def __init__(self, email):
+        self.email = email
+
+db.create_all()
+
+user1 = User(email='admin@example.com')
+user2 = User(email='admin2@example.com')
+db.session.add(user1)
+db.session.add(user2)
+db.session.commit()
+
+@app.route('/')
+def user_count():
+    user_info = json.loads(request.args['user_info'])
+    sql_query = "email='{}'".format(user_info['email'])
+    user_count = db.session.query(User).filter(sql_query).count()
+
+    return "Users found: {}".format(user_count)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/python/ql/test/experimental/query-tests/Security/CWE-089/sqlalchemy_flask_bad.py
+++ b/python/ql/test/experimental/query-tests/Security/CWE-089/sqlalchemy_flask_bad.py
@@ -32,5 +32,5 @@ def user_count():
 
     return "Users found: {}".format(user_count)
 
-if __name__ == '__main__':
-    app.run(debug=True)
+# if __name__ == '__main__':
+#     app.run(debug=True)

--- a/python/ql/test/experimental/query-tests/Security/CWE-089/sqlalchemy_flask_good.py
+++ b/python/ql/test/experimental/query-tests/Security/CWE-089/sqlalchemy_flask_good.py
@@ -1,0 +1,38 @@
+from flask import Flask, request
+from flask_sqlalchemy import SQLAlchemy
+import json
+from sqlalchemy.sql import text
+from sqlescapy import sqlescape
+
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+app.config['SQLALCHEMY_ECHO'] = True
+db = SQLAlchemy(app)
+
+class User(db.Model):
+    uid = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    email = db.Column(db.String(50))
+
+    def __init__(self, email):
+        self.email = email
+
+db.create_all()
+
+user1 = User(email='admin@example.com')
+user2 = User(email='admin2@example.com')
+db.session.add(user1)
+db.session.add(user2)
+db.session.commit()
+
+@app.route('/')
+def user_count():
+    user_info = json.loads(request.args['user_info'])
+    sanitized_input = sqlescape(user_info['email']))
+    sql_query = "email='{}'".format(sanitized_input)
+    user_count = db.session.query(User).filter(sql_query).count()
+
+    return "Users found: {}".format(user_count)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/python/ql/test/experimental/query-tests/Security/CWE-089/sqlalchemy_flask_good.py
+++ b/python/ql/test/experimental/query-tests/Security/CWE-089/sqlalchemy_flask_good.py
@@ -34,5 +34,5 @@ def user_count():
 
     return "Users found: {}".format(user_count)
 
-if __name__ == '__main__':
-    app.run(debug=True)
+# if __name__ == '__main__':
+#     app.run(debug=True)

--- a/python/ql/test/experimental/query-tests/Security/CWE-089/sqlalchemy_good.py
+++ b/python/ql/test/experimental/query-tests/Security/CWE-089/sqlalchemy_good.py
@@ -1,0 +1,37 @@
+import sqlalchemy
+from sqlalchemy import Column, Integer, String, ForeignKey, create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship, backref, sessionmaker, joinedload
+from sqlalchemy.sql import text
+from sqlescapy import sqlescape
+
+
+engine = create_engine('sqlite:///:memory:', echo=True)
+Base = declarative_base()
+
+class User(Base):
+    __tablename__ = 'users'
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+
+Base.metadata.create_all(engine)
+
+Session = sessionmaker(bind=engine)
+session = Session()
+
+ed_user = User(name='ed')
+ed_user2 = User(name='george')
+
+session.add(ed_user)
+session.add(ed_user2)
+
+session.commit()
+
+
+malicious_user_input = sys.argv[1]
+escaped_input = sqlescape(malicious_user_input)
+sql_text = "name='{}'".format(escaped_input)
+sql_query = text(sql_text)
+
+session.query(User).filter(malicious_user_input).count()


### PR DESCRIPTION
WIP

## TODOS

- [x] Answer question: Is text() always needed? This post doesn't seem to say so https://stackoverflow.com/a/37572676
- [x] Answer question: Furthermore, that post arises that distinct() is also vulnerable, is it?
- [x] Remove DataToDict code
- [x] Add SqlAlchemy sink code
- [ ] Add Flask SqlAlchemy sink code
- [x] Re-test vulnerable sinks ensuring that SQLi is possible.
- [x] Update examples and remove json.loads
- [ ] Update query with latest results from thorough testing of SqlAlchemy
- [ ] Run query on select projects
- [x] Test select statements -https://docs.sqlalchemy.org/en/14/tutorial/data.html#the-select-sql-expression-construct (I believe this is irrelevant since it ultimately passes to #execute which we already know is vulnerable)

## Vulnerable Sinks

### filter (vulnerable) 
Requires `text()` in order to pass string into the `filter` method.

Confirmed this is vulnerable via sqlmap. `sqlmap --level=5 -u http://localhost:5000/?name=hello --dbms=sqlite`

```python
vulnerable_sql = "name='{}'".format("'' sqlite3_sleep(5)")

the_text = text(vulnerable_sql)

user_by_email = session.query(User)\
    .filter(the_text)\
    .first()


print(user_by_email)
```

### filter_by (vulnerable)

See [here](https://docs.sqlalchemy.org/en/14/orm/query.html#sqlalchemy.orm.Query.filter_by).

The `text()` method is optional.

However, in order for this to be vulnerable a developer uses `text()` SQL injection the code IS vulnerable. When directly inputting a string into `filter_by` SQL injection is NOT possible. This was based on sqlmap results.

`sqlmap --level=5 -u http://localhost:5000/?name=hell --dbms=sqlite -p "name"`

```python
vulnerable_sql = "name='{}'".format("' sqlite3_sleep(5)'")

the_text = text(vulnerable_sql)

user_by_email = session.query(User)\
    .filter_by(name=the_text)\
    .first()


print(user_by_email)
```

### having (vulnerable)

See [here](https://docs.sqlalchemy.org/en/14/orm/query.html#sqlalchemy.orm.Query.having).



`text()` is required to pass a string into the `having()` argument.

Confirmed this is vulnerable via sqlmap: `sqlmap --level=5 -u http://localhost:5000/?name=hell --dbms=sqlite -p "name" --risk=3`

```python
vulnerable_sql = "name='{}'".format("ed'; SELECT *'")

the_text = text(vulnerable_sql)

user_by_email = session.query(User)\
    .group_by( User.id )\
    .having(the_text)\
    .first()


print(user_by_email)
```

Please note that the `having` method MUST be used in conjunction with the `group_by` method. In my testing (at least with SQLite), SQLite requires that the `group_by` method be called alongside `group_by`. The order of the methods do not matter.

### group_by (vulnerable)
See [here](https://docs.sqlalchemy.org/en/14/orm/query.html#sqlalchemy.orm.Query.group_by).

`text()` is required if you want to pass a string into `group_by`.

Confirmed this is vulnerable via sqlmap: `sqlmap --level=5 -u http://localhost:5000/?name=hell --dbms=sqlite -p "name" --risk=3 --answers="extending=y"`

```python
vulnerable_sql = "name='{}'".format("ed'; SELECT *")

the_text = text(vulnerable_sql)

user_by_email = session.query(User)\
    .group_by( the_text )\
    .first()


print(user_by_email)
```

~~Please note that the `having` method MUST be used in conjunction with the `group_by` method. In my testing (at least with SQLite), SQLite requires that the `group_by` method be called alongside `group_by`. The order of the methods do not matter.~~


### order_by (vulnerable)
See [here](https://docs.sqlalchemy.org/en/14/orm/query.html#sqlalchemy.orm.Query.order_by).

This looks to be vulnerable as well.

`text()` is required if you want to pass a string into the `order_by` method.

Confirmed that this is vulnerable via sqlmap: `sqlmap --level=5 -u http://localhost:5000/?name=hell --dbms=sqlite -p "name" --risk=3 --answers="extending=y"`

```python
vulnerable_sql = "'{}'".format("edasdfasdf'; SELECT * FROM users;")

the_text = text(vulnerable_sql)

user_by_email = session.query(User)\
    .order_by(the_text)\
    .first()


print(user_by_email)
```


### scalar (vulnerable)
See [here](https://docs.sqlalchemy.org/en/14/orm/session_api.html#sqlalchemy.orm.Session.scalar).

This is vulnerable. Should be noted that you don't need to wrap the `text` function around the SQL statement. Also, within the documentation it's stated that:

> Usage and parameters are the same as that of Session.execute(); the return result is a scalar Python value.

And we know that `Session.execute()` is vulnerable.

```python
result = session.scalar(";SELECT * FROM users")

print(result)
```

This can also be written as which is also euqlly vulnerable and was tested via sqlmap...

```python
engine.scalar(vulnerable_sql)
```

### session.execute (vulnerable)

Tested on sqlmap and is vulnerable.

The `text()` method is optional.

```python
from sqlalchemy import select
result = session.execute("SELECT * FROM users")
```

### connection.execute (vulnerable)

Tested on sqlmap and is vulnerable.

The `text()` method is optional.

```python
with engine.connect() as connection:
    result = connection.execute("select username from users")
    for row in result:
        print("username:", row['username'])
```

another example:

```python
with engine.begin() as connection:
    connection.execute(text("insert into table values ('foo')"))
```

See [here](https://docs.sqlalchemy.org/en/13/core/connections.html).
 

### where 

This is a strange one because it's only vulnerable if a developer passes the dangerous input through `text()`. If they just pass the string directly to the query, there's no vulnerability. Tested on sqlmap.

sqlmap command: `sqlmap --level=5 -u http://localhost:5000/?name= --dbms=sqlite -p "name" --risk=3`

```python
    vulnerable_sql = request.args['name']
    the_text = text(vulnerable_sql)

    query = select(User).where(User.name == the_text)

    with engine.connect() as conn:
        answer = conn.execute(query)

        return "Users found: {}".format(answer)
```



## Vulnerable but not worthy of pursuing


### do_orm_execute (vulnerable but see my notes below)

More info [here](https://docs.sqlalchemy.org/en/14/orm/events.html#sqlalchemy.orm.SessionEvents.do_orm_execute) and [here](https://docs.sqlalchemy.org/en/14/orm/session_events.html).

This is an interesting method. Essentially this is used as an event hook for when SQL statements are executed. Let's say you wanted to intercept a SQL statement before it's executed by SQLALchemy, you would use `do_orm_execute`. You may want to do this if you want to modify the statement in some way before it's executed, like adding some weird performant feature to the statement.

An example below:

```python
Session = sessionmaker(engine, future=True)

@event.listens_for(Session, "do_orm_execute")
def _do_orm_execute(orm_execute_state):
    if orm_execute_state.is_select:
        # add populate_existing for all SELECT statements

        orm_execute_state.update_execution_options(populate_existing=True)

        # check if the SELECT is against a certain entity and add an
        # ORDER BY if so
        col_descriptions = orm_execute_state.statement.column_descriptions

        if col_descriptions[0]['entity'] is MyEntity:
            orm_execute_state.statement = statement.order_by(MyEntity.name)
```

Although I believe this COULD result in a SQL injection, I don't think this feature is used often, on top of that, it's more difficult to imagine this being used in conjunction with user-controlled sources. I did a initial Github search and found that Github found only 80 code instances of the keyword `do_orm_execute`. See the results [here](https://github.com/search?q=do_orm_execute&type=code).

I'm curious what you think but I'm willing to pass on this. The costs outweigh the benefits in writing up a query that covers this scenario.


### invoke_statement (vulnerable but see my notes below)
See [here](https://docs.sqlalchemy.org/en/14/orm/session_api.html#sqlalchemy.orm.ORMExecuteState.invoke_statement).

I believe this is vulnerable to injection however I'm not so convinced that it's worth writing a query for. One reason is that I actually have had a little trouble finding a real-world use case. Also, the Github search results returned in only 19 cases of it being used in python code. See the results [here](https://github.com/search?l=Python&q=invoke_statement&type=Code).


### ORMExecuteState (vulnerable but see my notes below)

See [here](https://docs.sqlalchemy.org/en/14/orm/session_api.html#sqlalchemy.orm.ORMExecuteState).

Let me first state that I haven't tested this. That said, I believe this is part of the `do_orm_execute` event hook feature in SQLAlchemy. I'm not convinced this is worth pursing because of the the low usage found in Github [search results](https://github.com/search?l=Python&q=ORMExecuteState&type=Code) for the term ORMExecuteState.


## NOT Vulnerable Sinks

### distinct
See [here](https://docs.sqlalchemy.org/en/14/orm/query.html#sqlalchemy.orm.Query.distinct).

Requires `text()` if you want to pass a string into the `distinct` method.

This is vulnerable but I can only confirm that this works on postgresql. It does not work on sqlite.

Tested using the following command: `sqlmap --level=3 -u http://localhost:5000/?name= --dbms=postgresql -p "name" --risk=3 --ignore-code="500"`

```python
    vulnerable_sql = "".format(request.args['name'])

    the_text = text(vulnerable_sql)

    user_by_email = session.query(User)\
        .distinct(the_text)\
        .all()
```

## Sanitization Libraries

[sqlescapy](https://github.com/elouajib/sqlescapy) can sanitize SQL statements. However, two things to note:

- This library isn't used much. It only has 4 stars.
- According to an issue in the repo, the library is partially broken. It might be a good idea to fix this issue since it appears easy to fix. It would bolster us adding this to the CodeQL injection.

[Flask Security](https://flask-security-too.readthedocs.io/en/stable/quickstart.html#basic-sqlalchemy-application). This may be a potential sanitization library but I need to review this further.

## Real-world example of a vulnerability:
- N/A

# sources
- https://stackoverflow.com/questions/6501583/sqlalchemy-sql-injection/6501664
- https://docs.sqlalchemy.org/en/14/core/future.html
- https://docs.sqlalchemy.org/en/14/orm/query.html
- https://qr.ae/pG1F3W